### PR TITLE
Return None from require if module does not exist

### DIFF
--- a/js/src/main/scala/fr/hmil/roshttp/node/Global.scala
+++ b/js/src/main/scala/fr/hmil/roshttp/node/Global.scala
@@ -8,5 +8,5 @@ import scala.scalajs.js.annotation.JSName
   */
 @js.native
 private[roshttp] object Global extends js.GlobalScope {
-  def require[T](name: String): T = js.native
+  def require[T](name: String): js.UndefOr[T] = js.native
 }

--- a/js/src/main/scala/fr/hmil/roshttp/node/Helpers.scala
+++ b/js/src/main/scala/fr/hmil/roshttp/node/Helpers.scala
@@ -25,7 +25,7 @@ private[roshttp] object Helpers {
     if (!js.isUndefined(module.inst)) {
       Some(module.inst)
     } else if (isRequireAvailable) {
-      Some(Global.require[T](module.name))
+      Global.require[T](module.name).toOption
     } else {
       None
     }


### PR DESCRIPTION
This will change the behaviour of fr.hmil.roshttp.node.Helpers.require
to return None if the global require method exists but the required
module does not exist.

In a browser environment packaged by scalajs-bundle the require method
may be defined in order to allow interop with common js modules, and it
returns undefined if the desired module does not exist. The result is
that RosHTTP never uses the Browser driver but fails with
scala.scalajs.js.JavaScriptException: TypeError: Cannot read property
'request' of undefined.