### PR TITLE
#71:adding implicit conversion for boolean JSON value

### DIFF
--- a/project/InBrowserTesting.scala
+++ b/project/InBrowserTesting.scala
@@ -83,16 +83,16 @@ object InBrowserTesting {
           scalaJSUseRhino := false)))
 
   def js: Project => Project = {
-    val materializer = new CustomFileMaterializer("test/server/runtime", "http://localhost:3000/runtime")
+    //val materializer = new CustomFileMaterializer("test/server/runtime", "http://localhost:3000/runtime")
     _.configure(
-      browserConfig(ConfigFirefox, new SeleniumJSEnv(Firefox).withMaterializer(materializer)),
-      browserConfig(ConfigChrome, new SeleniumJSEnv(Chrome).withMaterializer(materializer)))
-    .settings(
-      testAll := {
-        (test in Test         ).value
-        (test in ConfigFirefox).value
-        (test in ConfigChrome ).value
-      })
+      browserConfig(ConfigFirefox, new SeleniumJSEnv(org.openqa.selenium.remote.DesiredCapabilities.firefox())),
+      browserConfig(ConfigChrome, new SeleniumJSEnv(org.openqa.selenium.remote.DesiredCapabilities.chrome())))
+      .settings(
+        testAll := {
+          (test in Test).value
+          (test in ConfigFirefox).value
+          (test in ConfigChrome).value
+        })
   }
 
   def jvm: Project => Project =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
-libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.3"
+libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.2.0"
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")

--- a/shared/src/main/scala/fr/hmil/roshttp/body/Implicits.scala
+++ b/shared/src/main/scala/fr/hmil/roshttp/body/Implicits.scala
@@ -11,6 +11,7 @@ object Implicits {
   implicit def intToJSONNumber(value: Int): JSONNumber = new JSONNumber(value)
   implicit def floatToJSONNumber(value: Float): JSONNumber = new JSONNumber(value)
   implicit def doubleToJSONNumber(value: Double): JSONNumber = new JSONNumber(value)
+  implicit def booleanToJSONBoolean(value:Boolean):JSONBoolean = new JSONBoolean(value)
   implicit def JSONObjectToJSONBody(obj: JSONObject): JSONBody = JSONBody(obj)
 
   implicit def byteBufferToByteBufferBody(buffer: ByteBuffer): BodyPart = ByteBufferBody(buffer)

--- a/shared/src/main/scala/fr/hmil/roshttp/body/JSONBody.scala
+++ b/shared/src/main/scala/fr/hmil/roshttp/body/JSONBody.scala
@@ -23,6 +23,10 @@ object JSONBody {
     override def toString: String = value.toString
   }
 
+  class JSONBoolean(value:Boolean) extends JSONValue {
+    override def toString: String = value.toString
+  }
+
   class JSONString(value: String) extends JSONValue {
     override def toString: String = "\"" + escapeJS(value) + "\""
   }

--- a/shared/src/test/scala/fr/hmil/roshttp/HttpRequestSpec.scala
+++ b/shared/src/test/scala/fr/hmil/roshttp/HttpRequestSpec.scala
@@ -540,12 +540,13 @@ object HttpRequestSpec extends TestSuite {
         "works as intended" - {
           val part = JSONObject(
             "foo" -> 42,
+            "bar" -> true,
             "engine" -> "Heizölrückstoßabdämpfung",
             "\"quoted'" -> "Has \" quotes")
           HttpRequest(s"$SERVER_URL/body")
             .post(part)
             .map({ res =>
-              res.body ==> "{\"foo\":42,\"engine\":\"Heizölrückstoßabdämpfung\"," +
+              res.body ==> "{\"foo\":42,\"bar\":true,\"engine\":\"Heizölrückstoßabdämpfung\"," +
                 "\"\\\"quoted'\":\"Has \\\" quotes\"}"
               res.headers("Content-Type").toLowerCase ==> s"application/json; charset=utf-8"
             })


### PR DESCRIPTION
Currently we are not able to pass boolean values as request parameters as implicit json converters are not available for boolean type. Add that now.

Refer issue : #71 