### PR TITLE
Drop Scala 2.10, 2.11, add Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ jdk:
   - oraclejdk8
 
 scala:
-  - 2.10.6
-  - 2.11.11
-  - 2.12.2
+  - 2.12.9
+  - 2.13.0
 
 install:
   - nvm list

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "RösHTTP root project"
 
-crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2")
+crossScalaVersions := Seq("2.12.9", "2.13.0")
 
 lazy val root = project.in(file("."))
   .aggregate(scalaHttpJS, scalaHttpJVM)
@@ -9,8 +9,8 @@ lazy val scalaHttp = crossProject.in(file("."))
   .configureCross(InBrowserTesting.cross)
   .settings(
     name := "roshttp",
-    version := "2.2.4",
-    scalaVersion := "2.11.11",
+    version := "2.2.5",
+    scalaVersion := "2.12.9",
     organization := "fr.hmil",
     licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
     homepage := Some(url("http://github.com/hmil/RosHTTP")),
@@ -30,8 +30,8 @@ lazy val scalaHttp = crossProject.in(file("."))
     ),
     pomIncludeRepository := { _ => false },
 
-    libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.5" % Test,
-    libraryDependencies += "io.monix" %%% "monix" % "2.3.3",
+    libraryDependencies += "com.lihaoyi" %%% "utest" % "0.6.9" % Test,
+    libraryDependencies += "io.monix" %%% "monix" % "3.0.0-RC3",
 
     testFrameworks += new TestFramework("utest.runner.Framework")
   )
@@ -40,7 +40,7 @@ lazy val scalaHttp = crossProject.in(file("."))
   )
   .jsSettings(
     // js-specific settings
-    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1",
+    libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.7",
 
     jsEnv := NodeJSEnv().value
   )

--- a/jvm/src/main/scala/fr/hmil/roshttp/HttpDriver.scala
+++ b/jvm/src/main/scala/fr/hmil/roshttp/HttpDriver.scala
@@ -136,6 +136,6 @@ private object HttpDriver extends DriverTrait {
       }
     }
 
-    Observable.fromIterator(iterator)
+    Observable.fromIteratorUnsafe(iterator)
   }
 }

--- a/project/InBrowserTesting.scala
+++ b/project/InBrowserTesting.scala
@@ -1,8 +1,8 @@
 import sbt._
 import sbt.Keys._
+import org.scalajs.sbtplugin.ScalaJSPluginInternal.scalaJSTestSettings
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import org.scalajs.sbtplugin.cross.CrossProject
-import org.scalajs.sbtplugin.ScalaJSPluginInternal._
 import org.scalajs.jsenv.selenium._
 
 object InBrowserTesting {
@@ -14,73 +14,7 @@ object InBrowserTesting {
 
   private def browserConfig(cfg: Configuration, env: SeleniumJSEnv): Project => Project =
     _.settings(
-      inConfig(cfg)(
-        Defaults.testSettings ++
-        scalaJSTestSettings ++
-        Seq(
-
-          // Scala.JS public settings
-          checkScalaJSSemantics         := (checkScalaJSSemantics         in Test).value,
-          emitSourceMaps                := (emitSourceMaps                in Test).value,
-          fastOptJS                     := (fastOptJS                     in Test).value,
-          fullOptJS                     := (fullOptJS                     in Test).value,
-          jsDependencies                := (jsDependencies                in Test).value,
-          jsDependencyFilter            := (jsDependencyFilter            in Test).value,
-          jsDependencyManifest          := (jsDependencyManifest          in Test).value,
-          jsDependencyManifests         := (jsDependencyManifests         in Test).value,
-          jsManifestFilter              := (jsManifestFilter              in Test).value,
-       // loadedJSEnv                   := (loadedJSEnv                   in Test).value,
-          packageJSDependencies         := (packageJSDependencies         in Test).value,
-          packageMinifiedJSDependencies := (packageMinifiedJSDependencies in Test).value,
-          packageScalaJSLauncher        := (packageScalaJSLauncher        in Test).value,
-          persistLauncher               := (persistLauncher               in Test).value,
-          relativeSourceMaps            := (relativeSourceMaps            in Test).value,
-          resolvedJSDependencies        := (resolvedJSDependencies        in Test).value,
-       // resolvedJSEnv                 := (resolvedJSEnv                 in Test).value,
-       // scalaJSConsole                := (scalaJSConsole                in Test).value,
-          scalaJSIR                     := (scalaJSIR                     in Test).value,
-          scalaJSLauncher               := (scalaJSLauncher               in Test).value,
-          scalaJSLinkedFile             := (scalaJSLinkedFile             in Test).value,
-          scalaJSNativeLibraries        := (scalaJSNativeLibraries        in Test).value,
-          scalaJSOptimizerOptions       := (scalaJSOptimizerOptions       in Test).value,
-          scalaJSOutputMode             := (scalaJSOutputMode             in Test).value,
-          scalaJSOutputWrapper          := (scalaJSOutputWrapper          in Test).value,
-          scalajsp                      := (scalajsp                      in Test).value,
-          scalaJSSemantics              := (scalaJSSemantics              in Test).value,
-          scalaJSStage                  := (scalaJSStage                  in Test).value,
-
-          // Scala.JS internal settings
-          scalaJSClearCacheStats := (scalaJSClearCacheStats in Test).value,
-          scalaJSEnsureUnforked  := (scalaJSEnsureUnforked  in Test).value,
-          scalaJSIRCacheHolder   := (scalaJSIRCacheHolder   in Test).value,
-          scalaJSIRCache         := (scalaJSIRCache         in Test).value,
-          scalaJSLinker          := (scalaJSLinker          in Test).value,
-          scalaJSRequestsDOM     := (scalaJSRequestsDOM     in Test).value,
-          sjsirFilesOnClasspath  := (sjsirFilesOnClasspath  in Test).value,
-          usesScalaJSLinkerTag   := (usesScalaJSLinkerTag   in Test).value,
-
-          // SBT test settings
-          definedTestNames     := (definedTestNames     in Test).value,
-          definedTests         := (definedTests         in Test).value,
-       // executeTests         := (executeTests         in Test).value,
-       // loadedTestFrameworks := (loadedTestFrameworks in Test).value,
-       // testExecution        := (testExecution        in Test).value,
-       // testFilter           := (testFilter           in Test).value,
-          testForkedParallel   := (testForkedParallel   in Test).value,
-       // testFrameworks       := (testFrameworks       in Test).value,
-          testGrouping         := (testGrouping         in Test).value,
-       // testListeners        := (testListeners        in Test).value,
-       // testLoader           := (testLoader           in Test).value,
-       // testOnly             := (testOnly             in Test).value,
-          testOptions          := (testOptions          in Test).value,
-       // testQuick            := (testQuick            in Test).value,
-          testResultLogger     := (testResultLogger     in Test).value,
-       // test                 := (test                 in Test).value,
-
-          // In-browser settings
-          jsEnv           := env,
-          requiresDOM     := true,
-          scalaJSUseRhino := false)))
+      inConfig(cfg)(Defaults.testSettings ++ scalaJSTestSettings))
 
   def js: Project => Project = {
     //val materializer = new CustomFileMaterializer("test/server/runtime", "http://localhost:3000/runtime")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,3 +1,3 @@
-sbt.version = 0.13.15
+sbt.version = 1.2.8
 
 set logLevel in Global := Level.Debug

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
-libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.2.0"
+libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.3.0"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 
-addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.2")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")

--- a/shared/src/main/scala/fr/hmil/roshttp/body/Implicits.scala
+++ b/shared/src/main/scala/fr/hmil/roshttp/body/Implicits.scala
@@ -17,5 +17,5 @@ object Implicits {
 
   implicit def byteBufferToByteBufferBody(buffer: ByteBuffer): BodyPart = ByteBufferBody(buffer)
   implicit def observableToStreamBody(is: InputStream): BodyPart =
-    StreamBody(Observable.fromInputStream(is).map(ByteBuffer.wrap))
+    StreamBody(Observable.fromInputStreamUnsafe(is).map(ByteBuffer.wrap))
 }

--- a/shared/src/test/scala/fr/hmil/roshttp/HttpRequestSpec.scala
+++ b/shared/src/test/scala/fr/hmil/roshttp/HttpRequestSpec.scala
@@ -253,7 +253,7 @@ object HttpRequestSpec extends TestSuite {
               assert(buffer.limit <= config.maxChunkSize)
             })
             .bufferTumbling(3)
-            .firstL.runAsync
+            .firstL.runToFuture
           )
       }
     }
@@ -625,7 +625,7 @@ object HttpRequestSpec extends TestSuite {
           }
           "is properly sent" - {
             val part = MultiPartBody(
-              "stream" -> StreamBody(Observable.fromIterator(new Iterator[ByteBuffer]() {
+              "stream" -> StreamBody(Observable.fromIteratorUnsafe(new Iterator[ByteBuffer]() {
                 private var emitted = false
                 override def hasNext: Boolean = !emitted
                 override def next(): ByteBuffer = {

--- a/shared/src/test/scala/fr/hmil/roshttp/StreamingPressureTest.scala
+++ b/shared/src/test/scala/fr/hmil/roshttp/StreamingPressureTest.scala
@@ -19,7 +19,7 @@ object StreamingPressureTest extends TestSuite {
     "Upload streams do not leak" - {
       if (!JsEnvUtils.isRealBrowser) {
         HttpRequest(s"$SERVER_URL/streams/in")
-          .post(StreamBody(Observable.fromIterator(new Iterator[ByteBuffer]() {
+          .post(StreamBody(Observable.fromIteratorUnsafe(new Iterator[ByteBuffer]() {
             override def hasNext: Boolean = true
             override def next(): ByteBuffer = ByteBuffer.allocateDirect(8192)
           })


### PR DESCRIPTION
Hi @hmil, I was going to ask about 2.13 migration, but started to toy a bit with dependencies and ended up with a minimal PR that works for 2.12 and 2.13 (whole test set is green). It's still a sketch that we can work on top of.

The main problem here is that Scala support for 2.10 and 2.11 needs to be dropped, and I'm not sure if you still want to maintain them in the short term. Also bumping monix ends up with a bunch of `unsafe` methods that still require a bit of polishing.